### PR TITLE
parallel build support for ffibuilder.compile()

### DIFF
--- a/src/cffi/api.py
+++ b/src/cffi/api.py
@@ -707,7 +707,7 @@ class FFI(object):
         recompile(self, module_name, source,
                   c_file=filename, call_c_compiler=False, **kwds)
 
-    def compile(self, tmpdir='.', verbose=0, target=None, debug=None):
+    def compile(self, tmpdir='.', verbose=0, target=None, debug=None, parallel=None):
         """The 'target' argument gives the final file name of the
         compiled DLL.  Use '*' to force distutils' choice, suitable for
         regular CPython C API modules.  Use a file name ending in '.*'
@@ -724,7 +724,7 @@ class FFI(object):
         module_name, source, source_extension, kwds = self._assigned_source
         return recompile(self, module_name, source, tmpdir=tmpdir,
                          target=target, source_extension=source_extension,
-                         compiler_verbose=verbose, debug=debug, **kwds)
+                         compiler_verbose=verbose, debug=debug, parallel=parallel, **kwds)
 
     def init_once(self, func, tag):
         # Read _init_once_cache[tag], which is either (False, lock) if

--- a/src/cffi/ffiplatform.py
+++ b/src/cffi/ffiplatform.py
@@ -12,12 +12,12 @@ def get_extension(srcfilename, modname, sources=(), **kwds):
         allsources.append(os.path.normpath(src))
     return Extension(name=modname, sources=allsources, **kwds)
 
-def compile(tmpdir, ext, compiler_verbose=0, debug=None):
+def compile(tmpdir, ext, compiler_verbose=0, debug=None, parallel=None):
     """Compile a C extension module using distutils."""
 
     saved_environ = os.environ.copy()
     try:
-        outputfilename = _build(tmpdir, ext, compiler_verbose, debug)
+        outputfilename = _build(tmpdir, ext, compiler_verbose, debug, parallel)
         outputfilename = os.path.abspath(outputfilename)
     finally:
         # workaround for a distutils bugs where some env vars can
@@ -27,7 +27,7 @@ def compile(tmpdir, ext, compiler_verbose=0, debug=None):
                 os.environ[key] = value
     return outputfilename
 
-def _build(tmpdir, ext, compiler_verbose=0, debug=None):
+def _build(tmpdir, ext, compiler_verbose=0, debug=None, parallel=None):
     # XXX compact but horrible :-(
     from cffi._shimmed_dist_utils import Distribution, CompileError, LinkError, set_threshold, set_verbosity
 
@@ -40,6 +40,7 @@ def _build(tmpdir, ext, compiler_verbose=0, debug=None):
     options['force'] = ('ffiplatform', True)
     options['build_lib'] = ('ffiplatform', tmpdir)
     options['build_temp'] = ('ffiplatform', tmpdir)
+    options['parallel'] = ('ffiplatform', parallel)
     #
     try:
         old_level = set_threshold(0) or 0

--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -1519,7 +1519,7 @@ def _patch_for_target(patchlist, target):
 
 def recompile(ffi, module_name, preamble, tmpdir='.', call_c_compiler=True,
               c_file=None, source_extension='.c', extradir=None,
-              compiler_verbose=1, target=None, debug=None, **kwds):
+              compiler_verbose=1, target=None, debug=None, parallel=None, **kwds):
     if not isinstance(module_name, str):
         module_name = module_name.encode('ascii')
     if ffi._windows_unicode:
@@ -1562,7 +1562,7 @@ def recompile(ffi, module_name, preamble, tmpdir='.', call_c_compiler=True,
                     print('%s %r' % (msg, os.path.abspath(tmpdir)))
                 os.chdir(tmpdir)
                 outputfilename = ffiplatform.compile('.', ext,
-                                                     compiler_verbose, debug)
+                                                     compiler_verbose, debug, parallel)
             finally:
                 os.chdir(cwd)
                 _unpatch_meths(patchlist)


### PR DESCRIPTION
Is there any real reason this wasn't added yet?

```python
from cffi import FFI

from multiprocessing import cpu_count

ffibuilder = FFI()
...
ffibuilder.compile(verbose=True, parallel=multiprocessing.cpu_count())
```