### PR TITLE
use public Py_HashPointer API on 3.13+

### DIFF
--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -2457,7 +2457,11 @@ static Py_hash_t cdata_hash(PyObject *v)
         }
         Py_DECREF(vv);
     }
+#if PY_VERSION_HEX >= 0x030D0000
     return _Py_HashPointer(((CDataObject *)v)->c_data);
+#else
+    return Py_HashPointer(((CDataObject *)v)->c_data);
+#endif
 }
 
 static Py_ssize_t


### PR DESCRIPTION
fixes #51

* use newly-public `Py_HashPointer` API on 3.13+
