### PR TITLE
Win32: pass the flags from dlopen() to LoadLibraryEx()

### DIFF
--- a/doc/source/cdef.rst
+++ b/doc/source/cdef.rst
@@ -381,6 +381,14 @@ Useful if you have special needs (e.g. you need the GNU extension
 automatically if the FFI object is garbage-collected (but you can still
 call ``ffi.dlclose()`` explicitly if needed).
 
+*New in version 1.17:* on Windows, ``ffi.dlopen(filename, flags=0)`` now
+passes the flags to ``LoadLibraryEx()``.  Moreover, if you use the
+default value of 0 but ``filename`` contains a slash or backslash
+character, it will instead use
+``LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR``.
+This ensures that dependent DLLs from the same path are also found.
+It is what ctypes does too.
+
 
 .. _set_source:
 

--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -4570,7 +4570,7 @@ static void *b_do_dlopen(PyObject *args, const char **p_printable_filename,
             if (sz1 < 0)
                 return NULL;
             w1[sz1] = 0;
-            handle = dlopenW(w1);
+            handle = dlopenWinW(w1, flags);
             goto got_handle;
         }
         PyErr_Clear();

--- a/src/c/misc_win32.h
+++ b/src/c/misc_win32.h
@@ -194,7 +194,7 @@ static PyObject *b_getwinerror(PyObject *self, PyObject *args, PyObject *kwds)
 static void *dlopen(const char *filename, int flags)
 {
     if (flags == 0) {
-        for (char *p = filename; *p != 0; p++)
+        for (const char *p = filename; *p != 0; p++)
             if (*p == '\\' || *p == '/') {
                 flags = LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
                         LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;
@@ -207,7 +207,7 @@ static void *dlopen(const char *filename, int flags)
 static void *dlopenWinW(const wchar_t *filename, int flags)
 {
     if (flags == 0) {
-        for (wchar_t *p = filename; *p != 0; p++)
+        for (const wchar_t *p = filename; *p != 0; p++)
             if (*p == '\\' || *p == '/') {
                 flags = LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
                         LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;

--- a/src/c/misc_win32.h
+++ b/src/c/misc_win32.h
@@ -191,14 +191,30 @@ static PyObject *b_getwinerror(PyObject *self, PyObject *args, PyObject *kwds)
 #define RTLD_GLOBAL 0
 #define RTLD_LOCAL  0
 
-static void *dlopen(const char *filename, int flag)
+static void *dlopen(const char *filename, int flags)
 {
-    return (void *)LoadLibraryA(filename);
+    if (flags == 0) {
+        for (char *p = filename; *p != 0; p++)
+            if (*p == '\\' || *p == '/') {
+                flags = LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
+                        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;
+                break;
+            }
+    }
+    return (void *)LoadLibraryExA(filename, NULL, flags);
 }
 
-static void *dlopenW(const wchar_t *filename)
+static void *dlopenWinW(const wchar_t *filename, int flags)
 {
-    return (void *)LoadLibraryW(filename);
+    if (flags == 0) {
+        for (wchar_t *p = filename; *p != 0; p++)
+            if (*p == '\\' || *p == '/') {
+                flags = LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
+                        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;
+                break;
+            }
+    }
+    return (void *)LoadLibraryExW(filename, NULL, flags);
 }
 
 static void *dlsym(void *handle, const char *symbol)


### PR DESCRIPTION
Includes a default handling if flags==0, similar to the one in ctypes.