### PR TITLE
Build `aarch64` `musllinux` wheel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,6 @@ jobs:
           # HACK: private musllinux_1_1 container build with 3.13 prerelease support
           manylinux_img: quay.io/rolpdog/musllinux_1_1_x86_64:latest
 
-
         - spec: cp39-musllinux_i686
         - spec: cp310-musllinux_i686
         - spec: cp311-musllinux_i686
@@ -87,6 +86,21 @@ jobs:
           # HACK: private manylinux_2_28 container build with 3.13 prerelease support
           manylinux_img: quay.io/rolpdog/manylinux_2_28_aarch64:latest
 
+        - spec: cp38-musllinux_aarch64
+          foreign_arch: true
+          test_args: '{project}/src/c'
+        - spec: cp39-musllinux_aarch64
+          foreign_arch: true
+          test_args: '{project}/src/c'
+        - spec: cp310-musllinux_aarch64
+          foreign_arch: true
+          test_args: '{project}/src/c'
+        - spec: cp311-musllinux_aarch64
+          foreign_arch: true
+          test_args: '{project}/src/c'
+        - spec: cp312-musllinux_aarch64
+          foreign_arch: true
+          test_args: '{project}/src/c'
 
         - spec: cp38-manylinux_ppc64le
           foreign_arch: true
@@ -144,6 +158,7 @@ jobs:
           ldconfig || true
         CIBW_ENVIRONMENT_PASS_LINUX: CFLAGS  # ensure that the build container can see our overridden build config
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_img || '' }}
+        CIBW_MUSLLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MUSLLINUX_X86_64_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_img || '' }}


### PR DESCRIPTION
[super-linter](https://github.com/super-linter/super-linter) is preparing for arm64 support https://github.com/super-linter/super-linter/issues/5070. It would be very helpful to have a `musllinux_aarch64` wheel

Fix #41