### PR TITLE
Add 3.13 to trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,7 @@ Contact
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
+            'Programming Language :: Python :: 3.13',
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
             'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Since 3.13 is part of the CI, it's fair to call it supported.

Also, please give us a new release 🐶 – I expect the 3.13 horde at my argon2-cffi gates any moment. 😅