### PR TITLE
Fix rendering of "GitHub" link.

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -57,7 +57,7 @@ Download and Installation:
   install cffi yet, you need first ``python setup_base.py build_ext -f
   -i``)
 
-.. _`GitHub project home`: https://github.com/python-cffi/cffi
+.. _`GitHub`: https://github.com/python-cffi/cffi
 
 Demos:
 


### PR DESCRIPTION
Before: 
![image](https://github.com/python-cffi/cffi/assets/620848/9fa9a6a0-7999-44f3-a0ec-992f3ee2c7ca)

After:
![image](https://github.com/python-cffi/cffi/assets/620848/ee7e0e17-5715-41a4-82dd-8dd2ec4b3e48)
