### PR TITLE
Avoid Py_FileSystemDefaultEncoding in 3.12+

### DIFF
--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -204,6 +204,10 @@
 # define USE_WRITEUNRAISABLEMSG
 #endif
 
+#if PY_VERSION_HEX >= 0x030c0000
+# define Py_FileSystemDefaultEncoding PyConfig.filesystem_encoding
+#endif
+
 /************************************************************/
 
 /* base type flag: exactly one of the following: */


### PR DESCRIPTION
This has been [deprecated](https://docs.python.org/3/whatsnew/3.12.html#id6), and hence emits build warnings, which will eventually become errors.

Thus avoid it using the same mechanism that's already being used in similar situations.

First seen in https://github.com/ICRAR/ijson/actions/runs/8996107055/job/24712097518#step:7:81