### PR TITLE
Cast offset to size_t to avoid c++11-narrowing warning

### DIFF
--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -953,7 +953,7 @@ class Recompiler:
                 if cname is None or fbitsize >= 0:
                     offset = '(size_t)-1'
                 elif named_ptr is not None:
-                    offset = '((char *)&((%s)4096)->%s) - (char *)4096' % (
+                    offset = '(size_t)(((char *)&((%s)4096)->%s) - (char *)4096)' % (
                         named_ptr.name, fldname)
                 else:
                     offset = 'offsetof(%s, %s)' % (tp.get_c_name(''), fldname)


### PR DESCRIPTION
e.g. with clang 18 on chimera linux:

_CFFI_test_verify_anonymous_struct_with_star_typedef.cpp:583:10: error: non-constant-expression cannot be narrowed from type 'long' to 'size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
  583 |   { "a", ((char *)&((foo_t)4096)->a) - (char *)4096,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
_CFFI_test_verify_anonymous_struct_with_star_typedef.cpp:583:10: note: insert an explicit cast to silence this issue
  583 |   { "a", ((char *)&((foo_t)4096)->a) - (char *)4096,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |          static_cast<size_t>(                      )
