### PR TITLE
Fix undefined names in Python code

### DIFF
--- a/demo/_curses.py
+++ b/demo/_curses.py
@@ -5,6 +5,11 @@ from functools import wraps
 
 from _curses_cffi import ffi, lib
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 def _copy_to_globals(name):
     globals()[name] = getattr(lib, name)

--- a/demo/bsdopendirtype.py
+++ b/demo/bsdopendirtype.py
@@ -1,3 +1,4 @@
+import os
 from _bsdopendirtype import ffi, lib
 
 

--- a/demo/recopendirtype.py
+++ b/demo/recopendirtype.py
@@ -1,3 +1,4 @@
+import os
 from _recopendirtype import ffi, lib
 
 

--- a/src/cffi/verifier.py
+++ b/src/cffi/verifier.py
@@ -22,7 +22,7 @@ if sys.version_info >= (3,):
 else:
     class NativeIO(io.BytesIO):
         def write(self, s):
-            if isinstance(s, unicode):
+            if isinstance(s, unicode):  # noqa: F821
                 s = s.encode('ascii')
             super(NativeIO, self).write(s)
 

--- a/testing/cffi0/test_zdistutils.py
+++ b/testing/cffi0/test_zdistutils.py
@@ -242,7 +242,7 @@ class DistUtilsTest(object):
         prev_compile = ffiplatform.compile
         try:
             if targetpackage == ext_package:
-                ffiplatform.compile = lambda *args: dont_call_me_any_more
+                ffiplatform.compile = lambda *args: dont_call_me_any_more  # noqa: F821
             # won't find it in tmpdir, but should find it correctly
             # installed in udir
             ffi, lib = make_ffi()

--- a/testing/cffi1/test_recompiler.py
+++ b/testing/cffi1/test_recompiler.py
@@ -745,7 +745,7 @@ def test_include_8():
 
 def test_unicode_libraries():
     try:
-        unicode
+        unicode  # noqa: F821
     except NameError:
         pytest.skip("for python 2.x")
     #
@@ -757,9 +757,10 @@ def test_unicode_libraries():
         if distutils.ccompiler.get_default_compiler() == 'msvc':
             lib_m = 'msvcrt'
     ffi = FFI()
-    ffi.cdef(unicode("float sin(double); double cos(double);"))
-    lib = verify(ffi, 'test_math_sin_unicode', unicode('#include <math.h>'),
-                 libraries=[unicode(lib_m)], ignore_warnings=True)
+    ffi.cdef(unicode("float sin(double); double cos(double);"))  # noqa: F821
+    lib = verify(ffi, 'test_math_sin_unicode',
+                 unicode('#include <math.h>'),  # noqa: F821
+                 libraries=[unicode(lib_m)], ignore_warnings=True)  # noqa: F821
     assert lib.cos(1.43) == math.cos(1.43)
 
 def test_incomplete_struct_as_arg():

--- a/testing/support.py
+++ b/testing/support.py
@@ -9,7 +9,7 @@ if sys.version_info < (3,):
             return eval('u'+repr(other).replace(r'\\u', r'\u')
                                        .replace(r'\\U', r'\U'))
     u = U()
-    long = long     # for further "from testing.support import long"
+    long = long     # noqa: F821 for further "from testing.support import long"
     assert u+'a\x00b' == eval(r"u'a\x00b'")
     assert u+'a\u1234b' == eval(r"u'a\u1234b'")
     assert u+'a\U00012345b' == eval(r"u'a\U00012345b'")


### PR DESCRIPTION
% `ruff check --select=E9,F63,F7,F82 --output-format=concise`

And then fix the resulting undefined names except in file `testing/cffi1/test_re_python.py`.