### PR TITLE
ruff check --select=E --fix --unsafe-fixes

### DIFF
--- a/demo/cffi-cocoa.py
+++ b/demo/cffi-cocoa.py
@@ -60,14 +60,14 @@ NSApplicationActivationPolicyRegular = ffi.cast('NSApplicationActivationPolicy',
 NSTitledWindowMask = ffi.cast('NSUInteger', 1)
 NSBackingStoreBuffered = ffi.cast('NSBackingStoreType', 2)
 
-NSMakePoint = lambda x, y: ffi.new('NSPoint *', (x, y))[0]
-NSMakeRect = lambda x, y, w, h: ffi.new('NSRect *', ((x, y), (w, h)))[0]
+def NSMakePoint(x, y):
+    return ffi.new('NSPoint *', (x, y))[0]
+def NSMakeRect(x, y, w, h):
+    return ffi.new('NSRect *', ((x, y), (w, h)))[0]
 
 get, send, sel = objc.objc_getClass, objc.objc_msgSend, objc.sel_registerName
-at = lambda s: send(
-    get('NSString'),
-    sel('stringWithCString:encoding:'),
-    ffi.new('char[]', s), NSASCIIStringEncoding)
+def at(s):
+    return send(get('NSString'), sel('stringWithCString:encoding:'), ffi.new('char[]', s), NSASCIIStringEncoding)
 
 send(get('NSAutoreleasePool'), sel('new'))
 app = send(get('NSApplication'), sel('sharedApplication'))

--- a/demo/pwuid.py
+++ b/demo/pwuid.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import sys, os
+import sys
+import os
 
 # run pwuid_build first, then make sure the shared object is on sys.path
 from _pwuid_cffi import ffi, lib

--- a/demo/winclipboard.py
+++ b/demo/winclipboard.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 __author__ = "Israel Fruchter <israel.fruchter@gmail.com>"
 
-import sys, os
+import sys
+import os
 
 if not sys.platform == 'win32':
     raise Exception("Windows-only demo")

--- a/demo/xclient.py
+++ b/demo/xclient.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 
 # run xclient_build first, then make sure the shared object is on sys.path
 from _xclient_cffi import ffi, lib

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-import sys, os, platform
+import sys
+import os
+import platform
 import subprocess
 import errno
 

--- a/setup_base.py
+++ b/setup_base.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 
 
 from setup import include_dirs, sources, libraries, define_macros

--- a/src/c/test_c.py
+++ b/src/c/test_c.py
@@ -18,7 +18,8 @@ if sys.platform == 'linux':
         pass
 
 def _setup_path():
-    import os, sys
+    import os
+    import sys
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 _setup_path()
 from _cffi_backend import *
@@ -71,7 +72,8 @@ if sys.version_info < (3,):
     mandatory_b_prefix = ''
     mandatory_u_prefix = 'u'
     bytechr = chr
-    bitem2bchr = lambda x: x
+    def bitem2bchr(x):
+        return x
     class U(object):
         def __add__(self, other):
             return eval('u'+repr(other).replace(r'\\u', r'\u')
@@ -86,10 +88,12 @@ else:
     unichr = chr
     mandatory_b_prefix = 'b'
     mandatory_u_prefix = ''
-    bytechr = lambda n: bytes([n])
+    def bytechr(n):
+        return bytes([n])
     bitem2bchr = bytechr
     u = ""
-    str2bytes = lambda s: bytes(s, "ascii")
+    def str2bytes(s):
+        return bytes(s, 'ascii')
     strict_compare = True
 
 def size_of_int():
@@ -457,7 +461,7 @@ def test_reading_pointer_to_pointer():
     assert p[0] is not None
     assert p[0] == cast(BVoidP, 0)
     assert p[0] == cast(BCharP, 0)
-    assert p[0] != None
+    assert p[0] is not None
     assert repr(p[0]) == "<cdata 'int *' NULL>"
     p[0] = q
     assert p[0] != cast(BVoidP, 0)
@@ -492,12 +496,12 @@ def test_no_len_on_nonarray():
 def test_cmp_none():
     p = new_primitive_type("int")
     x = cast(p, 42)
-    assert (x == None) is False
-    assert (x != None) is True
+    assert (x is None) is False
+    assert (x is not None) is True
     assert (x == ["hello"]) is False
     assert (x != ["hello"]) is True
     y = cast(p, 0)
-    assert (y == None) is False
+    assert (y is None) is False
 
 def test_invalid_indexing():
     p = new_primitive_type("int")
@@ -2988,7 +2992,8 @@ def test_string_assignment_to_byte_array():
 # XXX hack
 if sys.version_info >= (3,):
     try:
-        import posix, io
+        import posix
+        import io
         posix.fdopen = io.open
     except ImportError:
         pass   # win32

--- a/src/cffi/api.py
+++ b/src/cffi/api.py
@@ -1,4 +1,5 @@
-import sys, types
+import sys
+import types
 from .lock import allocate_lock
 from .error import CDefError
 from . import model
@@ -8,7 +9,8 @@ try:
 except NameError:
     # Python 3.1
     from collections import Callable
-    callable = lambda x: isinstance(x, Callable)
+    def callable(x):
+        return isinstance(x, Callable)
 
 try:
     basestring
@@ -414,7 +416,7 @@ class FFI(object):
         if (replace_with.startswith('*')
                 and '&[' in self._backend.getcname(cdecl, '&')):
             replace_with = '(%s)' % replace_with
-        elif replace_with and not replace_with[0] in '[(':
+        elif replace_with and replace_with[0] not in '[(':
             replace_with = ' ' + replace_with
         return self._backend.getcname(cdecl, replace_with)
 

--- a/src/cffi/backend_ctypes.py
+++ b/src/cffi/backend_ctypes.py
@@ -1,4 +1,7 @@
-import ctypes, ctypes.util, operator, sys
+import ctypes
+import ctypes.util
+import operator
+import sys
 from . import model
 
 if sys.version_info < (3,):
@@ -7,7 +10,8 @@ else:
     unicode = str
     long = int
     xrange = range
-    bytechr = lambda num: bytes([num])
+    def bytechr(num):
+        return bytes([num])
 
 class CTypesType(type):
     pass

--- a/src/cffi/cparser.py
+++ b/src/cffi/cparser.py
@@ -5,7 +5,9 @@ try:
     from . import _pycparser as pycparser
 except ImportError:
     import pycparser
-import weakref, re, sys
+import weakref
+import re
+import sys
 
 try:
     if sys.version_info < (3,):
@@ -370,7 +372,7 @@ class Parser(object):
     def parse(self, csource, override=False, packed=False, pack=None,
                     dllexport=False):
         if packed:
-            if packed != True:
+            if packed is not True:
                 raise ValueError("'packed' should be False or True; use "
                                  "'pack' to give another value")
             if pack:

--- a/src/cffi/ffiplatform.py
+++ b/src/cffi/ffiplatform.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 from .error import VerificationError
 
 

--- a/src/cffi/model.py
+++ b/src/cffi/model.py
@@ -34,7 +34,7 @@ class BaseTypeByIdentity(object):
         if replace_with:
             if replace_with.startswith('*') and '&[' in result:
                 replace_with = '(%s)' % replace_with
-            elif not replace_with[0] in '[(':
+            elif replace_with[0] not in '[(':
                 replace_with = ' ' + replace_with
         replace_with = qualify(quals, replace_with)
         result = result.replace('&', replace_with)

--- a/src/cffi/pkgconfig.py
+++ b/src/cffi/pkgconfig.py
@@ -1,5 +1,7 @@
 # pkg-config, https://www.freedesktop.org/wiki/Software/pkg-config/ integration for cffi
-import sys, os, subprocess
+import sys
+import os
+import subprocess
 
 from .error import PkgConfigError
 

--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -1,4 +1,6 @@
-import os, sys, io
+import os
+import sys
+import io
 from . import ffiplatform, model
 from .error import VerificationError
 from .cffi_opcode import *

--- a/src/cffi/vengine_gen.py
+++ b/src/cffi/vengine_gen.py
@@ -1,7 +1,8 @@
 #
 # DEPRECATED: implementation for ffi.verify()
 #
-import sys, os
+import sys
+import os
 import types
 
 from . import model

--- a/src/cffi/verifier.py
+++ b/src/cffi/verifier.py
@@ -1,7 +1,11 @@
 #
 # DEPRECATED: implementation for ffi.verify()
 #
-import sys, os, binascii, shutil, io
+import sys
+import os
+import binascii
+import shutil
+import io
 from . import __version_verifier_modules__
 from . import ffiplatform
 from .error import VerificationError

--- a/testing/cffi0/backend_tests.py
+++ b/testing/cffi0/backend_tests.py
@@ -1,6 +1,8 @@
 import pytest
 import platform
-import sys, ctypes, ctypes.util
+import sys
+import ctypes
+import ctypes.util
 from cffi import FFI, CDefError, FFIError, VerificationMissing
 from testing.support import *
 
@@ -197,7 +199,7 @@ class BackendTests:
         assert p is not None
         assert bool(p) is False
         assert p == ffi.cast("int*", 0)
-        assert p != None
+        assert p is not None
         assert repr(p) == "<cdata 'int *' NULL>"
         a = ffi.new("int[]", [123, 456])
         p = ffi.cast("int*", a)
@@ -387,7 +389,7 @@ class BackendTests:
         ffi = FFI(backend=self.Backend())
         p = ffi.new("int*[1]")
         assert p[0] is not None
-        assert p[0] != None
+        assert p[0] is not None
         assert p[0] == ffi.NULL
         assert repr(p[0]) == "<cdata 'int *' NULL>"
         #
@@ -1144,14 +1146,14 @@ class BackendTests:
         assert (p >  q) is False
         assert (p >= q) is False
         #
-        assert (None == s) is False
-        assert (None != s) is True
-        assert (s == None) is False
-        assert (s != None) is True
-        assert (None == q) is False
-        assert (None != q) is True
-        assert (q == None) is False
-        assert (q != None) is True
+        assert (None is s) is False
+        assert (None is not s) is True
+        assert (s is None) is False
+        assert (s is not None) is True
+        assert (None is q) is False
+        assert (None is not q) is True
+        assert (q is None) is False
+        assert (q is not None) is True
 
     def test_integer_comparison(self):
         ffi = FFI(backend=self.Backend())
@@ -1230,7 +1232,9 @@ class BackendTests:
 
     def test_ffi_buffer_with_file(self):
         ffi = FFI(backend=self.Backend())
-        import tempfile, os, array
+        import tempfile
+        import os
+        import array
         fd, filename = tempfile.mkstemp()
         f = os.fdopen(fd, 'r+b')
         a = ffi.new("int[]", list(range(1005)))
@@ -1250,7 +1254,8 @@ class BackendTests:
 
     def test_ffi_buffer_with_io(self):
         ffi = FFI(backend=self.Backend())
-        import io, array
+        import io
+        import array
         f = io.BytesIO()
         a = ffi.new("int[]", list(range(1005)))
         try:
@@ -1957,7 +1962,8 @@ class BackendTests:
             assert seen == [1, 1]
 
     def test_init_once_multithread(self):
-        import sys, time
+        import sys
+        import time
         if sys.version_info < (3,):
             import thread
         else:

--- a/testing/cffi0/callback_in_thread.py
+++ b/testing/cffi0/callback_in_thread.py
@@ -1,4 +1,5 @@
-import sys, time
+import sys
+import time
 sys.path.insert(0, sys.argv[1])
 from cffi import FFI
 

--- a/testing/cffi0/test_ffi_backend.py
+++ b/testing/cffi0/test_ffi_backend.py
@@ -1,4 +1,5 @@
-import sys, platform
+import sys
+import platform
 import pytest
 from testing.cffi0 import backend_tests, test_function, test_ownlib
 from testing.support import u
@@ -160,7 +161,8 @@ class TestFFI(backend_tests.BackendTests,
         assert p.foo.data[3] != 78   # has been overwritten with 9999999
 
     def test_issue553(self):
-        import gc, warnings
+        import gc
+        import warnings
         ffi = FFI(backend=self.Backend())
         p = ffi.new("int *", 123)
         with warnings.catch_warnings(record=True) as w:
@@ -169,7 +171,8 @@ class TestFFI(backend_tests.BackendTests,
         assert w == []
 
     def test_issue553_from_buffer(self):
-        import gc, warnings
+        import gc
+        import warnings
         ffi = FFI(backend=self.Backend())
         buf = b"123"
         with warnings.catch_warnings(record=True) as w:

--- a/testing/cffi0/test_function.py
+++ b/testing/cffi0/test_function.py
@@ -1,6 +1,8 @@
 import pytest
 from cffi import FFI, CDefError
-import math, os, sys
+import math
+import os
+import sys
 import ctypes.util
 from cffi.backend_ctypes import CTypesBackend
 from testing.udir import udir

--- a/testing/cffi0/test_ownlib.py
+++ b/testing/cffi0/test_ownlib.py
@@ -1,5 +1,7 @@
-import sys, os
-import subprocess, weakref
+import sys
+import os
+import subprocess
+import weakref
 import pytest
 from cffi import FFI
 from cffi.backend_ctypes import CTypesBackend

--- a/testing/cffi0/test_parsing.py
+++ b/testing/cffi0/test_parsing.py
@@ -1,4 +1,5 @@
-import sys, re
+import sys
+import re
 import pytest
 from cffi import FFI, FFIError, CDefError, VerificationError
 from .backend_tests import needs_dlopen_none

--- a/testing/cffi0/test_unicode_literals.py
+++ b/testing/cffi0/test_unicode_literals.py
@@ -7,7 +7,8 @@ from __future__ import unicode_literals
 #
 #
 #
-import sys, math
+import sys
+import math
 from cffi import FFI
 from testing.support import is_musl
 

--- a/testing/cffi0/test_verify.py
+++ b/testing/cffi0/test_verify.py
@@ -1,6 +1,9 @@
 import re
 import pytest
-import sys, os, math, weakref
+import sys
+import os
+import math
+import weakref
 from cffi import FFI, VerificationError, VerificationMissing, model, FFIError
 from testing.support import *
 from testing.support import extra_compile_args, is_musl
@@ -1424,7 +1427,8 @@ def test_ffi_struct_packed():
     """)
 
 def test_tmpdir():
-    import tempfile, os
+    import tempfile
+    import os
     from testing.udir import udir
     tmpdir = tempfile.mkdtemp(dir=str(udir))
     ffi = FFI()
@@ -1434,7 +1438,8 @@ def test_tmpdir():
     assert lib.foo(100) == 142
 
 def test_relative_to():
-    import tempfile, os
+    import tempfile
+    import os
     from testing.udir import udir
     tmpdir = tempfile.mkdtemp(dir=str(udir))
     ffi = FFI()
@@ -1599,7 +1604,8 @@ def test_addressof():
 def test_callback_in_thread():
     if sys.platform == 'win32':
         pytest.skip("pthread only")
-    import os, subprocess
+    import os
+    import subprocess
     from cffi import _imp_emulation as imp
     arg = os.path.join(os.path.dirname(__file__), 'callback_in_thread.py')
     g = subprocess.Popen([sys.executable, arg,

--- a/testing/cffi0/test_version.py
+++ b/testing/cffi0/test_version.py
@@ -1,6 +1,8 @@
-import os, sys
+import os
+import sys
 import pytest
-import cffi, _cffi_backend
+import cffi
+import _cffi_backend
 from pathlib import Path
 
 def setup_module(mod):

--- a/testing/cffi0/test_zdistutils.py
+++ b/testing/cffi0/test_zdistutils.py
@@ -1,4 +1,7 @@
-import sys, os, math, shutil
+import sys
+import os
+import math
+import shutil
 import pytest
 from cffi import FFI, FFIError
 from cffi.verifier import Verifier, _locate_engine_class, _get_so_suffixes

--- a/testing/cffi0/test_zintegration.py
+++ b/testing/cffi0/test_zintegration.py
@@ -1,4 +1,7 @@
-import py, os, sys, shutil
+import py
+import os
+import sys
+import shutil
 import subprocess
 import textwrap
 from testing.udir import udir
@@ -189,7 +192,7 @@ class TestZIntegration(object):
 
             setuptools.__version__ = '25.0'
             kwds = _set_py_limited_api(Extension, {})
-            assert kwds.get('py_limited_api', False) == False
+            assert kwds.get('py_limited_api', False) is False
 
             setuptools.__version__ = 'development'
             kwds = _set_py_limited_api(Extension, {})

--- a/testing/cffi1/test_cffi_binary.py
+++ b/testing/cffi1/test_cffi_binary.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import pytest
 import _cffi_backend
 from testing.support import is_musl

--- a/testing/cffi1/test_commontypes.py
+++ b/testing/cffi1/test_commontypes.py
@@ -1,4 +1,6 @@
-import os, cffi, re
+import os
+import cffi
+import re
 import pytest
 import _cffi_backend
 

--- a/testing/cffi1/test_ffi_obj.py
+++ b/testing/cffi1/test_ffi_obj.py
@@ -33,7 +33,8 @@ def test_ffi_cache_type():
     assert ffi.typeof("int(*)()") is ffi.typeof("int(*)()")
 
 def test_ffi_type_not_immortal():
-    import weakref, gc
+    import weakref
+    import gc
     ffi = _cffi1_backend.FFI()
     t1 = ffi.typeof("int **")
     t2 = ffi.typeof("int *")

--- a/testing/cffi1/test_function_args.py
+++ b/testing/cffi1/test_function_args.py
@@ -1,4 +1,5 @@
-import pytest, sys
+import pytest
+import sys
 try:
     # comment out the following line to run this test.
     # the latest on x86-64 linux: https://github.com/libffi/libffi/issues/574
@@ -15,7 +16,8 @@ except ImportError as e:
 else:
 
     from cffi import FFI
-    import sys, random
+    import sys
+    import random
     from .test_recompiler import verify
 
     ALL_PRIMITIVES = [

--- a/testing/cffi1/test_new_ffi_1.py
+++ b/testing/cffi1/test_new_ffi_1.py
@@ -1,6 +1,8 @@
 import pytest
 import platform
-import sys, os, ctypes
+import sys
+import os
+import ctypes
 import cffi
 from testing.udir import udir
 from testing.support import *
@@ -265,7 +267,7 @@ class TestNewFFI1:
         assert p is not None
         assert bool(p) is False
         assert p == ffi.cast("int*", 0)
-        assert p != None
+        assert p is not None
         assert repr(p) == "<cdata 'int *' NULL>"
         a = ffi.new("int[]", [123, 456])
         p = ffi.cast("int*", a)
@@ -446,7 +448,7 @@ class TestNewFFI1:
     def test_none_as_null_doesnt_work(self):
         p = ffi.new("int*[1]")
         assert p[0] is not None
-        assert p[0] != None
+        assert p[0] is not None
         assert p[0] == ffi.NULL
         assert repr(p[0]) == "<cdata 'int *' NULL>"
         #
@@ -1130,14 +1132,14 @@ class TestNewFFI1:
         assert (p >  q) is False
         assert (p >= q) is False
         #
-        assert (None == s) is False
-        assert (None != s) is True
-        assert (s == None) is False
-        assert (s != None) is True
-        assert (None == q) is False
-        assert (None != q) is True
-        assert (q == None) is False
-        assert (q != None) is True
+        assert (None is s) is False
+        assert (None is not s) is True
+        assert (s is None) is False
+        assert (s is not None) is True
+        assert (None is q) is False
+        assert (None is not q) is True
+        assert (q is None) is False
+        assert (q is not None) is True
 
     def test_integer_comparison(self):
         x = ffi.cast("int", 123)
@@ -1209,7 +1211,9 @@ class TestNewFFI1:
         assert ffi.buffer(a1)[:] == ffi.buffer(a2, 4*10)[:]
 
     def test_ffi_buffer_with_file(self):
-        import tempfile, os, array
+        import tempfile
+        import os
+        import array
         fd, filename = tempfile.mkstemp()
         f = os.fdopen(fd, 'r+b')
         a = ffi.new("int[]", list(range(1005)))
@@ -1228,7 +1232,8 @@ class TestNewFFI1:
         os.unlink(filename)
 
     def test_ffi_buffer_with_io(self):
-        import io, array
+        import io
+        import array
         f = io.BytesIO()
         a = ffi.new("int[]", list(range(1005)))
         try:

--- a/testing/cffi1/test_parse_c_type.py
+++ b/testing/cffi1/test_parse_c_type.py
@@ -1,4 +1,6 @@
-import sys, re, os
+import sys
+import re
+import os
 import pytest
 import cffi
 from cffi import cffi_opcode

--- a/testing/cffi1/test_re_python.py
+++ b/testing/cffi1/test_re_python.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import pytest
 from cffi import FFI
 from cffi import recompiler, ffiplatform, VerificationMissing

--- a/testing/cffi1/test_recompiler.py
+++ b/testing/cffi1/test_recompiler.py
@@ -1,5 +1,6 @@
 
-import sys, os
+import sys
+import os
 import pytest
 from cffi import FFI, VerificationError, FFIError, CDefError
 from cffi import recompiler
@@ -2045,7 +2046,7 @@ def test_function_returns_partial_struct():
 
 def test_function_returns_float_complex():
     ffi = FFI()
-    ffi.cdef("float _Complex f1(float a, float b);");
+    ffi.cdef("float _Complex f1(float a, float b);")
     if sys.platform == 'win32':
         lib = verify(ffi, "test_function_returns_float_complex", """
             #include <complex.h>
@@ -2063,7 +2064,7 @@ def test_function_returns_float_complex():
 
 def test_function_returns_double_complex():
     ffi = FFI()
-    ffi.cdef("double _Complex f1(double a, double b);");
+    ffi.cdef("double _Complex f1(double a, double b);")
     if sys.platform == 'win32':
         lib = verify(ffi, "test_function_returns_double_complex", """
             #include <complex.h>
@@ -2083,7 +2084,7 @@ def test_cdef_using_windows_complex():
     if sys.platform != 'win32':
         pytest.skip("only for MSVC")
     ffi = FFI()
-    ffi.cdef("_Fcomplex f1(float a, float b); _Dcomplex f2(double a, double b);");
+    ffi.cdef("_Fcomplex f1(float a, float b); _Dcomplex f2(double a, double b);")
     lib = verify(ffi, "test_cdef_using_windows_complex", """
         #include <complex.h>
         static _Fcomplex f1(float a, float b) { return _FCbuild(a, 2.0f*b); }
@@ -2100,7 +2101,7 @@ def test_cdef_using_windows_complex():
 
 def test_function_argument_float_complex():
     ffi = FFI()
-    ffi.cdef("float f1(float _Complex x);");
+    ffi.cdef("float f1(float _Complex x);")
     if sys.platform == 'win32':
         lib = verify(ffi, "test_function_argument_float_complex", """
             #include <complex.h>
@@ -2117,7 +2118,7 @@ def test_function_argument_float_complex():
 
 def test_function_argument_double_complex():
     ffi = FFI()
-    ffi.cdef("double f1(double _Complex);");
+    ffi.cdef("double f1(double _Complex);")
     if sys.platform == 'win32':
         lib = verify(ffi, "test_function_argument_double_complex", """
             #include <complex.h>

--- a/testing/cffi1/test_verify1.py
+++ b/testing/cffi1/test_verify1.py
@@ -1,4 +1,6 @@
-import os, sys, math
+import os
+import sys
+import math
 import pytest
 from cffi import FFI, FFIError, VerificationError, VerificationMissing, model
 from cffi import CDefError
@@ -1390,7 +1392,8 @@ def test_ffi_struct_packed():
     """)
 
 def test_tmpdir():
-    import tempfile, os
+    import tempfile
+    import os
     from testing.udir import udir
     tmpdir = tempfile.mkdtemp(dir=str(udir))
     ffi = FFI()
@@ -1401,7 +1404,8 @@ def test_tmpdir():
 
 def test_relative_to():
     pytest.skip("not available")
-    import tempfile, os
+    import tempfile
+    import os
     from testing.udir import udir
     tmpdir = tempfile.mkdtemp(dir=str(udir))
     ffi = FFI()
@@ -1558,7 +1562,8 @@ def test_callback_in_thread():
     pytest.xfail("adapt or remove")
     if sys.platform == 'win32':
         pytest.skip("pthread only")
-    import os, subprocess
+    import os
+    import subprocess
     from cffi import _imp_emulation as imp
     arg = os.path.join(os.path.dirname(__file__), 'callback_in_thread.py')
     g = subprocess.Popen([sys.executable, arg,

--- a/testing/cffi1/test_zdist.py
+++ b/testing/cffi1/test_zdist.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 import pytest
 import subprocess
 import cffi
@@ -39,7 +40,7 @@ class TestDist(object):
         # NOTE: pointing $HOME to a nonexistent directory can break certain things
         # that look there for configuration (like ccache).
         tmp_home = mkdtemp()
-        assert tmp_home != None, "cannot create temporary homedir"
+        assert tmp_home is not None, "cannot create temporary homedir"
         env['HOME'] = tmp_home
         pathlist = sys.path[:]
         if cwd is None:

--- a/testing/embedding/test_basic.py
+++ b/testing/embedding/test_basic.py
@@ -1,5 +1,9 @@
-import sys, os, re
-import shutil, subprocess, time
+import sys
+import os
+import re
+import shutil
+import subprocess
+import time
 import pytest
 from testing.udir import udir
 import cffi

--- a/testing/embedding/withunicode.py
+++ b/testing/embedding/withunicode.py
@@ -1,4 +1,5 @@
-import sys, cffi
+import sys
+import cffi
 if sys.version_info < (3,):
     u_prefix = "u"
 else:

--- a/testing/support.py
+++ b/testing/support.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 from cffi._imp_emulation import load_dynamic
 
 if sys.version_info < (3,):

--- a/testing/udir.py
+++ b/testing/udir.py
@@ -1,5 +1,7 @@
 import py
-import sys, os, atexit
+import sys
+import os
+import atexit
 
 
 # This is copied from PyPy's vendored py lib.  The latest py lib release


### PR DESCRIPTION
Let's consider this ___after___ #102 is merged so we can ensure that the pytests continue to pass with these changes.
* #102

Which [ruff rules E](https://docs.astral.sh/ruff/rules/#error-e) can be automatically fixed?

% `ruff check --statistics | grep "\[\*\]"`
```
  58	E401	[*] multiple-imports-on-one-line
  51	F841	[*] unused-variable
  25	E711	[*] none-comparison
   8	E731	[*] lambda-assignment
   5	E703	[*] useless-semicolon
   2	E712	[*] true-false-comparison
   2	E713	[*] not-in-test
```
% `ruff check --select=E --fix --unsafe-fixes`
```
Found 276 errors (100 fixed, 176 remaining).
```
% `ruff rule E731 ` # https://docs.astral.sh/ruff/rules/lambda-assignment
# lambda-assignment (E731)

Derived from the **pycodestyle** linter.

Fix is sometimes available.

## What it does
Checks for lambda expressions which are assigned to a variable.

## Why is this bad?
Per PEP 8, you should "Always use a def statement instead of an assignment
statement that binds a lambda expression directly to an identifier."

Using a `def` statement leads to better tracebacks, and the assignment
itself negates the primary benefit of using a `lambda` expression (i.e.,
that it can be embedded inside another expression).

## Example
```python
f = lambda x: 2 * x
```

Use instead:
```python
def f(x):
    return 2 * x
```

[PEP 8]: https://peps.python.org/pep-0008/#programming-recommendations
