### PR TITLE
limited api is not available in free-threaded cpython

### DIFF
--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -1,4 +1,5 @@
 import os, sys, io
+import sysconfig
 from . import ffiplatform, model
 from .error import VerificationError
 from .cffi_opcode import *
@@ -8,7 +9,8 @@ VERSION_EMBEDDED = 0x2701
 VERSION_CHAR16CHAR32 = 0x2801
 
 USE_LIMITED_API = (sys.platform != 'win32' or sys.version_info < (3, 0) or
-                   sys.version_info >= (3, 5))
+                   sys.version_info >= (3, 5)) \
+                  and not sysconfig.get_config_var("Py_GIL_DISABLED")
 
 
 class GlobalExpr:


### PR DESCRIPTION
related to #40

Free-threaded builds [don't support py_limited_api](https://docs.python.org/3.13/howto/free-threading-extensions.html#limited-c-api-and-stable-abi). Even setting `py_limited_api=False` still defines py_limited_api unless `_CFFI_NO_LIMITED_API` is _also_ defined (fixed here), so compilation would still fail with:

```
$PREFIX/include/python3.13t/Python.h:51:4: error: "The limited API is not currently supported in the free-threaded build"
#  error "The limited API is not currently supported in the free-threaded build"
```

Perhaps it is also bug that `set_source(py_limited_api=False)` still creates a source that defines Py_LIMITED_API on most systems?

(this is by no means "free-threaded support" for cffi, but one small step required to build cffi extensions _at all_ on free-threaded cpython)