### PR TITLE
avoid setting Py_LIMITED_API when py_limited_api=False

### DIFF
--- a/src/cffi/setuptools_ext.py
+++ b/src/cffi/setuptools_ext.py
@@ -101,6 +101,11 @@ def _set_py_limited_api(Extension, kwds):
             # try to set 'py_limited_api' anyway.  At worst, we get a
             # warning.
             kwds['py_limited_api'] = True
+
+    if not kwds.get('py_limited_api'):
+        # avoid setting Py_LIMITED_API if py_limited_api=False
+        # which _cffi_include.h does unless _CFFI_NO_LIMITED_API is defined
+        kwds.setdefault("define_macros", []).append(("_CFFI_NO_LIMITED_API", None))
     return kwds
 
 def _add_c_module(dist, ffi, module_name, source, source_extension, kwds):

--- a/src/cffi/setuptools_ext.py
+++ b/src/cffi/setuptools_ext.py
@@ -102,7 +102,7 @@ def _set_py_limited_api(Extension, kwds):
             # warning.
             kwds['py_limited_api'] = True
 
-    if not kwds.get('py_limited_api'):
+    if kwds.get('py_limited_api') is False:
         # avoid setting Py_LIMITED_API if py_limited_api=False
         # which _cffi_include.h does unless _CFFI_NO_LIMITED_API is defined
         kwds.setdefault("define_macros", []).append(("_CFFI_NO_LIMITED_API", None))


### PR DESCRIPTION
previously, setting `py_limited_api=False` only appeared to affect the ABI tag of modules, as Py_LIMITED_API was still unconditionally defined in most cases by `_cffi_include.h` [here](https://github.com/python-cffi/cffi/blob/fb6e5dce90e6404ffdcb2a3e35d110f5dae81337/src/cffi/_cffi_include.h#L52).

The changlog [says](https://cffi.readthedocs.io/en/stable/whatsnew.html#v1-14-2):

> You can manually disable Py_LIMITED_API by calling `ffi.set_source(..., py_limited_api=False)`.

but this doesn't appear to have been the case. With this change, the behavior matches at least my understanding of the docs on the matter.

The fact that setting `py_limited_api=False` didn't work is what led me to #104, which is unnecessary with this PR.