### PR TITLE
Remove now-obsolete NativeIO shim.

### DIFF
--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -1410,15 +1410,6 @@ class Recompiler:
         self.cffi_types[index] = CffiOp(OP_ENUM, enum_index)
 
 
-if sys.version_info >= (3,):
-    NativeIO = io.StringIO
-else:
-    class NativeIO(io.BytesIO):
-        def write(self, s):
-            if isinstance(s, unicode):
-                s = s.encode('ascii')
-            super(NativeIO, self).write(s)
-
 def _make_c_or_py_source(ffi, module_name, preamble, target_file, verbose):
     if verbose:
         print("generating %s" % (target_file,))
@@ -1426,7 +1417,7 @@ def _make_c_or_py_source(ffi, module_name, preamble, target_file, verbose):
                             target_is_python=(preamble is None))
     recompiler.collect_type_table()
     recompiler.collect_step_tables()
-    f = NativeIO()
+    f = io.StringIO()
     recompiler.write_source_to_f(f, preamble)
     output = f.getvalue()
     try:

--- a/src/cffi/verifier.py
+++ b/src/cffi/verifier.py
@@ -17,16 +17,6 @@ else:
                 if type == imp.C_EXTENSION]
 
 
-if sys.version_info >= (3,):
-    NativeIO = io.StringIO
-else:
-    class NativeIO(io.BytesIO):
-        def write(self, s):
-            if isinstance(s, unicode):
-                s = s.encode('ascii')
-            super(NativeIO, self).write(s)
-
-
 class Verifier(object):
 
     def __init__(self, ffi, preamble, tmpdir=None, modulename=None,
@@ -175,7 +165,7 @@ class Verifier(object):
             self._write_source_to(file)
         else:
             # Write our source file to an in memory file.
-            f = NativeIO()
+            f = io.StringIO()
             self._write_source_to(f)
             source_data = f.getvalue()
 


### PR DESCRIPTION
This was only needed for Python 2 compatibility, which was dropped in v1.16.0.