### PR TITLE
Handle distutils without distutils.msvc9compiler.MSVCCompiler class

### DIFF
--- a/src/cffi/_shimmed_dist_utils.py
+++ b/src/cffi/_shimmed_dist_utils.py
@@ -30,7 +30,10 @@ try:
     from distutils.log import set_threshold, set_verbosity
 
     if sys.platform == 'win32':
-        from distutils.msvc9compiler import MSVCCompiler
+        try:
+            from distutils.msvc9compiler import MSVCCompiler
+        except ImportError:
+            MSVCCompiler = None
 except Exception as ex:
     if sys.version_info >= (3, 12):
         raise Exception("This CFFI feature requires setuptools on Python >= 3.12. Please install the setuptools package.") from ex

--- a/src/cffi/_shimmed_dist_utils.py
+++ b/src/cffi/_shimmed_dist_utils.py
@@ -31,6 +31,7 @@ try:
 
     if sys.platform == 'win32':
         try:
+            # FUTURE: msvc9compiler module was removed in setuptools 74; consider removing, as it's only used by an ancient patch in `recompiler`
             from distutils.msvc9compiler import MSVCCompiler
         except ImportError:
             MSVCCompiler = None

--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -1483,6 +1483,8 @@ def _unpatch_meths(patchlist):
 def _patch_for_embedding(patchlist):
     if sys.platform == 'win32':
         # we must not remove the manifest when building for embedding!
+        # FUTURE: this module was removed in setuptools 74; this is likely dead code and should be removed,
+        #  since the toolchain it supports (VS2005-2008) is also long dead.
         from cffi._shimmed_dist_utils import MSVCCompiler
         if MSVCCompiler is not None:
             _patch_meth(patchlist, MSVCCompiler, '_remove_visual_c_ref',

--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -1484,8 +1484,9 @@ def _patch_for_embedding(patchlist):
     if sys.platform == 'win32':
         # we must not remove the manifest when building for embedding!
         from cffi._shimmed_dist_utils import MSVCCompiler
-        _patch_meth(patchlist, MSVCCompiler, '_remove_visual_c_ref',
-                    lambda self, manifest_file: manifest_file)
+        if MSVCCompiler is not None:
+            _patch_meth(patchlist, MSVCCompiler, '_remove_visual_c_ref',
+                        lambda self, manifest_file: manifest_file)
 
     if sys.platform == 'darwin':
         # we must not make a '-bundle', but a '-dynamiclib' instead


### PR DESCRIPTION
Fixes #117.