### PR TITLE
Remove uses of `distutils.msvc9compiler`

### DIFF
--- a/src/cffi/_shimmed_dist_utils.py
+++ b/src/cffi/_shimmed_dist_utils.py
@@ -28,9 +28,6 @@ try:
     from distutils.dir_util import mkpath
     from distutils.errors import DistutilsSetupError, CompileError, LinkError
     from distutils.log import set_threshold, set_verbosity
-
-    if sys.platform == 'win32':
-        from distutils.msvc9compiler import MSVCCompiler
 except Exception as ex:
     if sys.version_info >= (3, 12):
         raise Exception("This CFFI feature requires setuptools on Python >= 3.12. Please install the setuptools package.") from ex

--- a/src/cffi/recompiler.py
+++ b/src/cffi/recompiler.py
@@ -1481,12 +1481,6 @@ def _unpatch_meths(patchlist):
         setattr(cls, name, old_meth)
 
 def _patch_for_embedding(patchlist):
-    if sys.platform == 'win32':
-        # we must not remove the manifest when building for embedding!
-        from cffi._shimmed_dist_utils import MSVCCompiler
-        _patch_meth(patchlist, MSVCCompiler, '_remove_visual_c_ref',
-                    lambda self, manifest_file: manifest_file)
-
     if sys.platform == 'darwin':
         # we must not make a '-bundle', but a '-dynamiclib' instead
         from cffi._shimmed_dist_utils import CCompiler

--- a/testing/cffi0/test_ownlib.py
+++ b/testing/cffi0/test_ownlib.py
@@ -141,25 +141,13 @@ class TestOwnLib(object):
                 return
             # try (not too hard) to find the version used to compile this python
             # no mingw
-            from distutils.msvc9compiler import get_build_version
-            version = get_build_version()
-            toolskey = "VS%0.f0COMNTOOLS" % version
-            toolsdir = os.environ.get(toolskey, None)
-            if toolsdir is None:
-                return
-            productdir = os.path.join(toolsdir, os.pardir, os.pardir, "VC")
-            productdir = os.path.abspath(productdir)
-            vcvarsall = os.path.join(productdir, "vcvarsall.bat")
-            # 64?
-            arch = 'x86'
-            if sys.maxsize > 2**32:
-                arch = 'amd64'
-            if os.path.isfile(vcvarsall):
-                cmd = '"%s" %s' % (vcvarsall, arch) + ' & cl.exe testownlib.c ' \
-                        ' /LD /Fetestownlib.dll'
-                subprocess.check_call(cmd, cwd = str(udir), shell=True)
-                os.rename(str(udir) + '\\testownlib.dll', dll_path)
-                cls.module = dll_path
+            from setuptools.command.build_ext import new_compiler
+            compiler = new_compiler()
+            objs = compiler.compile([str(udir) + "\\testownlib.c"], output_dir=str(udir))
+            compiler.link_shared_lib(objs, str(udir) + "\\testownlib", extra_preargs = ["/DLL"])
+                
+            os.rename(str(udir) + '\\testownlib.dll', dll_path)
+            cls.module = dll_path
         else:
             encoded = None
             if cls.Backend is not CTypesBackend:

--- a/testing/cffi0/test_zdistutils.py
+++ b/testing/cffi0/test_zdistutils.py
@@ -90,7 +90,7 @@ class DistUtilsTest(object):
         csrc = '/*hi there %s!2*/\n#include <math.h>\n' % self
         v = Verifier(ffi, csrc, force_generic_engine=self.generic,
                      libraries=[self.lib_m])
-        basename = self.__class__.__name__[:10] + '_test_compile_module'
+        basename = self.__class__.__name__[4:14] + '_test_compile_module'
         v.modulefilename = filename = str(udir.join(basename + '.so'))
         v.compile_module()
         assert filename == v.modulefilename

--- a/testing/embedding/empty.py
+++ b/testing/embedding/empty.py
@@ -5,7 +5,7 @@ ffi = cffi.FFI()
 ffi.embedding_api("")
 
 ffi.set_source("_empty_cffi", """
-void initialize_my_empty_cffi(void) {
+CFFI_DLLEXPORT void initialize_my_empty_cffi(void) {
     if (cffi_start_python() != 0) {
         printf("oops, cffi_start_python() returned non-0\\n");
         abort();


### PR DESCRIPTION
`distutils.msvc9compiler` has been deprecated for a while, and has recently been removed, which breaks `cffi` on Windows.

This change:
* Removes the use of `distutils.msvc9compiler`.
* Removes the `_remove_visual_c_ref` workaround, as it's no longer required for `setuputils`.
* Changes `test_ownlib` to use the `CCompiler` API directly instead of manually running cl.exe.
* Fixes test failures:
  - `zdistutil` wasn't generating unique file names, as the first 10 characters of the test names were the same.
  - `empty-test` needs to export the function on Windows.

Fixes #117