### PR TITLE
Remove ResourceWarnings from tests

### DIFF
--- a/testing/cffi0/test_version.py
+++ b/testing/cffi0/test_version.py
@@ -15,6 +15,10 @@ def setup_module(mod):
 #    '0.8.4': '0.8.3',   # did not change
 #    }
 
+def _read(p):
+    with open(p) as f:
+        return f.read()
+
 def test_version():
     v = cffi.__version__
     version_info = '.'.join(str(i) for i in cffi.__version_info__)
@@ -28,7 +32,7 @@ def test_version():
 def test_doc_version():
     cffi_root = Path(os.path.dirname(__file__)).parent.parent
     p = cffi_root / 'doc/source/conf.py'
-    content = open(p).read()
+    content = _read(p)
     #
     v = cffi.__version__
     assert ("version = '%s'\n" % v[:4]) in content
@@ -37,7 +41,7 @@ def test_doc_version():
 def test_setup_version():
     cffi_root = Path(os.path.dirname(__file__)).parent.parent
     p = cffi_root / 'setup.py'
-    content = open(p).read()
+    content = _read(p)
     #
     v = cffi.__version__.replace('+', '')
     assert ("version='%s'" % v) in content
@@ -46,7 +50,7 @@ def test_c_version():
     cffi_root = Path(os.path.dirname(__file__)).parent.parent
     v = cffi.__version__
     p = cffi_root / 'src/c/test_c.py'
-    content = open(p).read()
+    content = _read(p)
     #v = BACKEND_VERSIONS.get(v, v)
     assert (('assert __version__ == "%s"' % v) in content)
 
@@ -54,5 +58,5 @@ def test_embedding_h():
     cffi_root = Path(os.path.dirname(__file__)).parent.parent
     v = cffi.__version__
     p = cffi_root / 'src/cffi/_embedding.h'
-    content = open(p).read()
+    content = _read(p)
     assert ('cffi version: %s"' % (v,)) in content

--- a/testing/cffi1/test_parse_c_type.py
+++ b/testing/cffi1/test_parse_c_type.py
@@ -17,7 +17,8 @@ cffi_dir = str(Path(os.path.dirname(__file__)).parent.parent / "src/cffi")
 r_macro = re.compile(r"#define \w+[(][^\n]*|#include [^\n]*")
 r_define = re.compile(r"(#define \w+) [^\n]*")
 r_ifdefs = re.compile(r"(#ifdef |#endif)[^\n]*")
-header = open(os.path.join(cffi_dir, 'parse_c_type.h')).read()
+with open(os.path.join(cffi_dir, 'parse_c_type.h')) as _header:
+    header = _header.read()
 header = r_macro.sub(r"", header)
 header = r_define.sub(r"\1 ...", header)
 header = r_ifdefs.sub(r"", header)
@@ -25,8 +26,10 @@ header = r_ifdefs.sub(r"", header)
 ffi = cffi.FFI()
 ffi.cdef(header)
 
+with open(os.path.join(cffi_dir, '..', 'c', 'parse_c_type.c')) as _body:
+    body = _body.read()
 lib = ffi.verify(
-        open(os.path.join(cffi_dir, '..', 'c', 'parse_c_type.c')).read() + """
+    body + """
 static const char *get_common_type(const char *search, size_t search_len) {
     return NULL;
 }

--- a/testing/embedding/test_basic.py
+++ b/testing/embedding/test_basic.py
@@ -60,8 +60,8 @@ class EmbeddingTests:
         popen = self._run_base(args, cwd=self.get_path(),
                                  stdout=subprocess.PIPE,
                                  universal_newlines=True)
-        output = popen.stdout.read()
-        err = popen.wait()
+        output, _ = popen.communicate()
+        err = popen.returncode
         if err:
             raise OSError(("popen failed with exit code %r: %r\n\n%s" % (
                 err, args, output)).rstrip())
@@ -169,8 +169,8 @@ if sys.platform == 'win32':
         popen = self._run_base([executable_name], cwd=path,
                                stdout=subprocess.PIPE,
                                universal_newlines=True)
-        result = popen.stdout.read()
-        err = popen.wait()
+        result, _ = popen.communicate()
+        err = popen.returncode
         if err:
             raise OSError("%r failed with exit code %r" % (
                 os.path.join(path, executable_name), err))


### PR DESCRIPTION
The open().read() calls were causing ResourceWarnings because the file was never explicitly closed, and are now replaced with a context managed open() call. In the case of the popens the reading from the stdout member had the same issue, so I'm replacing the stdout.read() + wait() with communicate() (which internally exhausts stdout and waits) + returncode.

All in all, this takes the warning count when running all tests from 45 down to 11, all of which are PytestUnraisableExceptionWarnings.