### PR TITLE
disable test_dlopen_handle on FreeBSD

### DIFF
--- a/testing/cffi0/test_ownlib.py
+++ b/testing/cffi0/test_ownlib.py
@@ -389,7 +389,7 @@ class TestOwnLib(object):
     def test_dlopen_handle(self):
         if self.module is None:
             pytest.skip("fix the auto-generation of the tiny test lib")
-        if sys.platform == 'win32' or is_musl:
+        if sys.platform == 'win32' or is_musl or sys.platform.startswith('freebsd'):
             pytest.skip("uses 'dl' explicitly")
         if self.__class__.Backend is CTypesBackend:
             pytest.skip("not for the ctypes backend")

--- a/testing/cffi1/test_re_python.py
+++ b/testing/cffi1/test_re_python.py
@@ -269,7 +269,7 @@ def test_selfref():
 def test_dlopen_handle():
     import _cffi_backend
     from re_python_pysrc import ffi
-    if sys.platform == 'win32' or is_musl:
+    if sys.platform == 'win32' or is_musl or sys.platform.startswith('freebsd'):
         pytest.skip("uses 'dl' explicitly")
     ffi1 = FFI()
     ffi1.cdef("""void *dlopen(const char *filename, int flags);


### PR DESCRIPTION
This test assumes that libdl.so's dlopen actually works, but [it does not](https://github.com/freebsd/freebsd-src/blob/main/lib/libc/gen/dlfcn.c#L117) on FreeBSD. You need to [link against libc](https://man.freebsd.org/cgi/man.cgi?query=dlopen&apropos=0&sektion=0&manpath=FreeBSD+14.1-RELEASE+and+Ports&arch=default&format=html) for the working function, but that provides the same error stub as libdl (see below). In order to get it to actually work correctly, the dynamic loader will resolve the weak function to a function defined within ld-elf.so itself, and so the test is not trivially fixable.

I can provide more FreeBSD system references if needed.

```
audrey@chrysanthemum:~/proj/nix/nixpkgs$ objdump -d /lib/libc.so.7 | grep -A8 '<dlopen>'
0000000000094d10 <dlopen>:
   94d10: 55                            pushq   %rbp
   94d11: 48 89 e5                      movq    %rsp, %rbp
   94d14: 48 8d 3d 05 45 fb ff          leaq    -0x4bafb(%rip), %rdi    # 0x49220
   94d1b: 31 c0                         xorl    %eax, %eax
   94d1d: e8 5e 4d 13 00                callq   0x1c9a80 <_rtld_error@plt>
   94d22: 31 c0                         xorl    %eax, %eax
   94d24: 5d                            popq    %rbp
   94d25: c3                            retq
```