### PR TITLE
Build ARM64 Windows wheels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -454,44 +454,68 @@ jobs:
         matrix_yaml: |
           include:
           - spec: cp38-win_amd64
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp39-win_amd64
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp310-win_amd64
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp311-win_amd64
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp312-win_amd64
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp313-win_amd64
+            image: windows-2022
             # omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp38-win32
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp39-win32
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp310-win32
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp311-win32
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp312-win32
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
 
           - spec: cp313-win32
+            image: windows-2022
             omit: ${{ env.skip_ci_redundant_jobs }}
+
+          - spec: cp311-win_arm64
+            image: windows-11-arm
+            omit: ${{ env.skip_ci_redundant_jobs }}
+
+          - spec: cp312-win_arm64
+            image: windows-11-arm
+            omit: ${{ env.skip_ci_redundant_jobs }}
+
+          - spec: cp313-win_arm64
+            image: windows-11-arm
+            # omit: ${{ env.skip_ci_redundant_jobs }}
 
   windows:
     needs: [python_sdist, make_windows_matrix]
-    runs-on: windows-2022
+    runs-on: ${{ matrix.image }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.make_windows_matrix.outputs.matrix_json) }}
@@ -502,6 +526,11 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ needs.python_sdist.outputs.sdist_artifact_name }}
+
+    - name: install python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
 
     - name: build/test wheels
       id: build


### PR DESCRIPTION
ARM64 Python is available since Python 3.11, so add specs for 3.11-3.13

Use actions/setup-python to avoid using the host Python (3.9 currently on windows-2022) since the arm image doesn't have a native Python atm (see https://github.com/actions/partner-runner-images/issues/85) and cibuildwheel warns that it will require 3.11 with v3, so might as well bump it for everything.

Also adds one arm64 build to the default matrix setup, since the separate image makes it different enough to warrant testing on PRs imo.

Fixes #109