### PR TITLE
Change the license from MIT to MIT-no-attribution...

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Except when otherwise stated (look for LICENSE files in directories or
 information at the beginning of each file) all software and
 documentation is licensed as follows: 
 
-    The MIT License
+    MIT No Attribution
 
     Permission is hereby granted, free of charge, to any person 
     obtaining a copy of this software and associated documentation 
@@ -11,10 +11,7 @@ documentation is licensed as follows:
     restriction, including without limitation the rights to use, 
     copy, modify, merge, publish, distribute, sublicense, and/or 
     sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included 
-    in all copies or substantial portions of the Software.
+    Software is furnished to do so.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
     OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 


### PR DESCRIPTION
…which is the same without the line that says "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software."

It should fix the "issue" reported here: https://groups.google.com/g/python-cffi/c/cbl-yazw3oE/m/2f8FCGYQFwAJ