### PR TITLE
Allow riscv64 package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,13 @@ jobs:
           - { spec: cp314-manylinux_s390x, arch: s390x, omit: ${{ env.skip_slow_jobs }} }
           - { spec: cp314t-manylinux_s390x, arch: s390x, omit: ${{ env.skip_slow_jobs }} }
 
+          # riscv64 manylinux
+          - { spec: cp39-manylinux_riscv64, arch: riscv64, omit: ${{ env.skip_slow_jobs  || env.skip_ci_redundant_jobs}}}
+          - { spec: cp310-manylinux_riscv64, arch: riscv64, omit: ${{ env.skip_slow_jobs  || env.skip_ci_redundant_jobs}}}
+          - { spec: cp311-manylinux_riscv64, arch: riscv64, omit: ${{ env.skip_slow_jobs  || env.skip_ci_redundant_jobs}}}
+          - { spec: cp312-manylinux_riscv64, arch: riscv64, omit: ${{ env.skip_slow_jobs  || env.skip_ci_redundant_jobs}}}
+          - { spec: cp313-manylinux_riscv64, arch: riscv64, omit: ${{ env.skip_slow_jobs  || env.skip_ci_redundant_jobs}}}
+
   linux:
     needs: [python_sdist, make_linux_matrix]
     runs-on: ${{ (matrix.arch == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}


### PR DESCRIPTION
PyPI recently added support for RISC-V, so we might consider adding support for RISC-V64.

Below are the CI results:
[CFFI CI](https://github.com/ffgan/cffi/actions/runs/16931415744)

The results are generally well presented.



Other Info
Co-authored by: [nijincheng@iscas.ac.cn](mailto:nijincheng@iscas.ac.cn);