### PR TITLE
Enable more Windows pytest-run-parallel CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -429,12 +429,6 @@ jobs:
         python -m pip install .
 
     - name: run tests under pytest-run-parallel
-      if: runner.os == 'Windows'
-      run: |
-        python -m pytest --parallel-threads=4 src/c
-
-    - name: run tests under pytest-run-parallel
-      if: runner.os != 'Windows'
       run: |
         python -m pytest --parallel-threads=4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -429,14 +429,8 @@ jobs:
         python -m pip install .
 
     - name: run tests under pytest-run-parallel
-      if: runner.os == 'Windows'
       run: |
         python -m pytest --parallel-threads=4 --skip-thread-unsafe=True
-
-    - name: run tests under pytest-run-parallel
-      if: runner.os != 'Windows'
-      run: |
-        python -m pytest --parallel-threads=4
 
   clang_TSAN:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -429,6 +429,12 @@ jobs:
         python -m pip install .
 
     - name: run tests under pytest-run-parallel
+      if: runner.os == 'Windows'
+      run: |
+        python -m pytest --parallel-threads=4 --skip-thread-unsafe=True
+
+    - name: run tests under pytest-run-parallel
+      if: runner.os != 'Windows'
       run: |
         python -m pytest --parallel-threads=4
 

--- a/testing/cffi1/test_function_args.py
+++ b/testing/cffi1/test_function_args.py
@@ -1,4 +1,9 @@
 import pytest, sys
+
+pytestmark = [
+    pytest.mark.thread_unsafe(reason="Workers would share a build directory"),
+]
+
 try:
     # comment out the following line to run this test.
     # the latest on x86-64 linux: https://github.com/libffi/libffi/issues/574


### PR DESCRIPTION
Towards #187.

This enables pytest-run-parallel CI on Windows for more tests. It also makes it so all platforms run the same tests under pytest-run-parallel.

Technically we're skipping tests now on Linux and Mac, but those tests are already being run in other CI jobs so no test coverage is lost.