### PR TITLE
Fix mingw build re atomic functions

### DIFF
--- a/src/c/misc_win32.h
+++ b/src/c/misc_win32.h
@@ -275,7 +275,9 @@ static int cffi_atomic_compare_exchange(void **ptr, void **expected,
 
 static void *cffi_atomic_load(void **ptr)
 {
-#if defined(_M_X64) || defined(_M_IX86)
+#if defined(__GNUC__) || defined(__clang__)
+    return __atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+#elif defined(_M_X64) || defined(_M_IX86)
     return *(volatile void **)ptr;
 #elif defined(_M_ARM64)
     return (void *)__ldar64((volatile unsigned __int64 *)ptr);
@@ -286,7 +288,9 @@ static void *cffi_atomic_load(void **ptr)
 
 static uint8_t cffi_atomic_load_uint8(uint8_t *ptr)
 {
-#if defined(_M_X64) || defined(_M_IX86)
+#if defined(__GNUC__) || defined(__clang__)
+    return __atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+#elif defined(_M_X64) || defined(_M_IX86)
     return *(volatile uint8_t *)ptr;
 #elif defined(_M_ARM64)
     return (uint8_t)__ldar8((volatile uint8_t *)ptr);
@@ -297,7 +301,9 @@ static uint8_t cffi_atomic_load_uint8(uint8_t *ptr)
 
 static Py_ssize_t cffi_atomic_load_ssize(Py_ssize_t *ptr)
 {
-#if defined(_M_X64) || defined(_M_IX86)
+#if defined(__GNUC__) || defined(__clang__)
+    return __atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+#elif defined(_M_X64) || defined(_M_IX86)
     return *(volatile Py_ssize_t *)ptr;
 #elif defined(_M_ARM64)
     return (Py_ssize_t)__ldar64((volatile unsigned __int64 *)ptr);
@@ -308,17 +314,29 @@ static Py_ssize_t cffi_atomic_load_ssize(Py_ssize_t *ptr)
 
 static void cffi_atomic_store_ssize(Py_ssize_t *ptr, Py_ssize_t value)
 {
+#if defined(__GNUC__) || defined(__clang__)
+    __atomic_store_n(ptr, value, __ATOMIC_SEQ_CST);
+#else
     _InterlockedExchangePointer(ptr, value);
+#endif
 }
 
 static void cffi_atomic_store(void **ptr, void *value)
 {
+#if defined(__GNUC__) || defined(__clang__)
+    __atomic_store_n(ptr, value, __ATOMIC_SEQ_CST);
+#else
     _InterlockedExchangePointer(ptr, value);
+#endif
 }
 
 static void cffi_atomic_store_uint8(uint8_t *ptr, uint8_t value)
 {
+#if defined(__GNUC__) || defined(__clang__)
+    __atomic_store_n(ptr, value, __ATOMIC_SEQ_CST);
+#else
     _InterlockedExchange8(ptr, value);
+#endif
 }
 
 #endif /* CFFI_MISC_WIN32_H */


### PR DESCRIPTION
Multiple issues making the build fail:

* _InterlockedExchange8 is missing in mingw-w64, filed in https://github.com/mingw-w64/mingw-w64/issues/118
* cffi_atomic_store_ssize is missing casts, leading to errors
* __ldar8/__ldar64 are not supported in gcc/clang

Just use the builtin compiler intrinsics everywhere for GCC/Clang when targeting Windows. Same as is already done in misc_thread_posix.h

See #159