### PR TITLE
Fix license in pyproject.toml to be compatible with PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.9"
 
 description = "Foreign Function Interface for Python calling C code."
 readme = {file = "README.md", content-type = "text/markdown"}
-license = "MIT"
+license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Update pyproject.toml to change the `license` field compatible with [PEP 621](https://peps.python.org/pep-0621/#license)

I'm not sure which is the best way to resolve this as the `license` is deprecated in a following [PEP 639](https://peps.python.org/pep-0639/) (which introduces `License-Expression`), but making this change will at least making new pip version (> 23.0.1) not complaining.