### PR TITLE
pyproject.toml: PEP 639 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ requires-python = ">=3.9"
 
 description = "Foreign Function Interface for Python calling C code."
 readme = "README.md"
-license = "MIT-0 AND MIT"
-license-files = ["LICENSE", "src/c/libffi_x86_x64/LICENSE"]
+license = "MIT-0"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Reverts #199 
Fixes #200

PEP 621 is superseded by PEP 639. The previous syntax is deprecated and will be removed in a future version of setuptools.

@Bluefissure @EpicWink @mattip