### PR TITLE
Minor updates in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ cffi_modules = "cffi.setuptools_ext:cffi_modules"
 [project.urls]
 Documentation = "https://cffi.readthedocs.io/"
 Changelog = "https://cffi.readthedocs.io/en/latest/whatsnew.html"
-Downloads = "https://github.com/python-cffi/cffi/releases"
+Download = "https://github.com/python-cffi/cffi/releases"
 Contact = "https://groups.google.com/forum/#!forum/python-cffi"
 "Source Code" = "https://github.com/python-cffi/cffi"
 "Issue Tracker" = "https://github.com/python-cffi/cffi/issues"


### PR DESCRIPTION
* https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#readme
  > The README’s format is auto-detected from the extension:
  > `README.md` → GitHub-flavored Markdown
* https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels
  Prefer well-known labels

