### PR TITLE
Manually apply ruff/flake8-implicit-str-concat rule ISC002

### DIFF
--- a/testing/cffi0/test_ownlib.py
+++ b/testing/cffi0/test_ownlib.py
@@ -156,8 +156,7 @@ class TestOwnLib:
             if sys.maxsize > 2**32:
                 arch = 'amd64'
             if os.path.isfile(vcvarsall):
-                cmd = '"%s" %s' % (vcvarsall, arch) + ' & cl.exe testownlib.c ' \
-                        ' /LD /Fetestownlib.dll'
+                cmd = f'"{vcvarsall}" {arch} & cl.exe testownlib.c /LD /Fetestownlib.dll'
                 subprocess.check_call(cmd, cwd = str(udir), shell=True)
                 os.rename(f"{udir}\\testownlib.dll", dll_path)
                 cls.module = dll_path


### PR DESCRIPTION
ISC002 Implicitly concatenated string literals over multiple lines