### PR TITLE
Make test_parsing more resilient to changes in pycparser

### DIFF
--- a/testing/cffi0/test_parsing.py
+++ b/testing/cffi0/test_parsing.py
@@ -365,7 +365,7 @@ def test_unknown_name():
     e = pytest.raises(CDefError, ffi.cast, "foobarbazunknown*", 0)
     assert str(e.value).startswith('cannot parse "foobarbazunknown*"')
     e = pytest.raises(CDefError, ffi.cast, "int(*)(foobarbazunknown)", 0)
-    assert str(e.value).startswith("in expression arg 1: unknown type 'foobarbazunknown'")
+    assert 'foobarbazunknown' in str(e.value)
 
 def test_redefine_common_type():
     prefix = "" if sys.version_info < (3,) else "b"


### PR DESCRIPTION
Several tests expect precise error messages from pycparser, which pycparser doesn't guarantee. While testing CFFI with pycparser 3.0, some tests needed to be made more resilient. I've used the .startswith() approach already used in this file, instead of exact string matching.

Ref #223