### PR TITLE
explicitly add string.h and stdlib.h headers

### DIFF
--- a/src/cffi/_cffi_include.h
+++ b/src/cffi/_cffi_include.h
@@ -59,6 +59,9 @@
 extern "C" {
 #endif
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "parse_c_type.h"
 
 /* this block of #ifs should be kept exactly identical between


### PR DESCRIPTION
Under newer limited C API versions, these headers are not included by default so this PR adds them explicitly to allow compilation.