### PR TITLE
do not crash on __delitem__

### DIFF
--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -2609,6 +2609,11 @@ cdata_ass_slice(CDataObject *cd, PySliceObject *slice, PyObject *v)
     cdata = cd->c_data + itemsize * bounds[0];
     length = bounds[1];
 
+    if (v == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+                        "'del x[n]' not supported for cdata objects");
+        return -1;
+    }
     if (CData_Check(v)) {
         CTypeDescrObject *ctv = ((CDataObject *)v)->c_type;
         if ((ctv->ct_flags & CT_ARRAY) && (ctv->ct_itemdescr == ct) &&

--- a/src/c/minibuffer.h
+++ b/src/c/minibuffer.h
@@ -243,6 +243,11 @@ static PyObject *mb_subscript(MiniBufferObj *self, PyObject *item)
 static int
 mb_ass_subscript(MiniBufferObj* self, PyObject* item, PyObject* value)
 {
+    if (value == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+                        "'del x[n]' not supported for buffer objects");
+        return -1;
+    }
     if (PyIndex_Check(item)) {
         Py_ssize_t i = PyNumber_AsSsize_t(item, PyExc_IndexError);
         if (i == -1 && PyErr_Occurred())

--- a/testing/cffi0/test_ffi_backend.py
+++ b/testing/cffi0/test_ffi_backend.py
@@ -587,6 +587,14 @@ class TestBitfield:
         p = ffi.new("int[]", [-123456789])
         assert ffi.unpack(p, 1) == [-123456789]
 
+    def test_delitem_raises(self):
+        ffi = FFI()
+        arr = ffi.new("int[5]")
+        buf = ffi.buffer(arr)
+        for obj in (arr, buf):
+            pytest.raises(TypeError, obj.__delitem__, 0) # del obj[0]
+            pytest.raises(TypeError, obj.__delitem__, slice(1, 3)) # del obj[1:3]
+
     def test_negative_array_size(self):
         ffi = FFI()
         pytest.raises(ValueError, ffi.cast, "int[-5]", 0)


### PR DESCRIPTION
what it says on the tin: we're forgetting to check for deletions in many cases, so it's easy to crash the python process by doing `del pointer[slice]` or `del buffer[anything]`