### PR TITLE
Add suppression for race seen in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -542,8 +542,12 @@ jobs:
 
     - name: build and install
       run: |
+        # these two steps can be removed when
+        # https://github.com/nascheme/cpython_sanity/issues/12 and the images
+        # are rebuilt
         apt update
         apt install -y llvm
+
         python -m pip install setuptools pytest pytest-run-parallel
         CFLAGS="-g -O3 -fsanitize=thread" python -m pip install -v .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -542,6 +542,8 @@ jobs:
 
     - name: build and install
       run: |
+        apt update
+        apt install -y llvm
         python -m pip install setuptools pytest pytest-run-parallel
         CFLAGS="-g -O3 -fsanitize=thread" python -m pip install -v .
 

--- a/suppressions_free_threading.txt
+++ b/suppressions_free_threading.txt
@@ -50,3 +50,6 @@ race_top:set_tp_bases
 race_top:type_set_bases_unlocked
 
 race:partial_vectorcall_fallback
+
+# gh-113956: races from simultaneously interning a string
+race_top:_Py_SetImmortalUntracked


### PR DESCRIPTION
Alternative to #243 with a more minimal change.

I think simply suppressing this warning is fine, this is an upstream issue and the race doesn't seem to have any impact on CFFI itself. See https://github.com/python/cpython/issues/113956.

Closes #242.