### PR TITLE
setup.py: fix cross-compilation on macOS hosts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ else:
     ask_supports_thread()
     ask_supports_sync_synchronize()
 
-if 'darwin' in sys.platform:
+if sysconfig.get_platform().startswith('macosx'):
     # priority is given to `pkg_config`, but always fall back on SDK's libffi.
     extra_compile_args += ['-iwithsysroot/usr/include/ffi']
 


### PR DESCRIPTION
When cross-compiling for a non-macOS target (such as Linux) on a macOS host, setup.py incorrectly detects the host platform as 'darwin' using sys.platform. This adds the macOS-specific flag -iwithsysroot/usr/include/ffi to the compiler arguments, which causes the cross-compiler to fail with:

```bash
    aarch64-openwrt-linux-musl-gcc: error: unrecognized command-line option '-iwithsysroot/usr/include/ffi'
```

By using sysconfig.get_platform().startswith('macosx') instead of 'darwin' in sys.platform, we correctly check the target platform rather than the build host. This allows successful cross-compilation on macOS hosts.