### PR TITLE
Fix flaky pytest-run-parallel CI crash

### DIFF
--- a/testing/cffi0/test_function.py
+++ b/testing/cffi0/test_function.py
@@ -280,6 +280,7 @@ class TestFunction:
         res = ffi.C.strlen(p)
         assert res == 5
 
+    @pytest.mark.thread_unsafe(reason="Mutates process-global libc stdout pointer")
     def test_write_variable(self):
         if not sys.platform.startswith('linux') or _is_musl:
             pytest.skip("probably no symbol 'stdout' in the lib")


### PR DESCRIPTION
While triggering a full CI run to test a v2.1 release, I happened to trigger a CI crash:

https://github.com/ngoldbaum/cffi-ft/actions/runs/28403191570/job/84159323543

I tracked it down to this test, which upon inspection is clearly not thread-safe. It mutates the process global libc stdout pointer. The correct fix is to mark it as thread-unsafe.