### PR TITLE
Mark test using inet_ntoa as thread-unsafe

### DIFF
--- a/testing/cffi0/test_function.py
+++ b/testing/cffi0/test_function.py
@@ -307,9 +307,9 @@ class TestFunction:
         q = ffi.C.strchr(p, ord('w'))
         assert ffi.string(q) == b"world!"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="no 'inet_ntoa'")
+    @pytest.mark.thread_unsafe(reason="inet_ntoa returns a globally shared static buffer on some systems")
     def test_function_with_struct_argument(self):
-        if sys.platform == 'win32':
-            pytest.skip("no 'inet_ntoa'")
         if (self.Backend is CTypesBackend and
             '__pypy__' in sys.builtin_module_names):
             pytest.skip("ctypes limitation on pypy")


### PR DESCRIPTION
I saw this failure in the CI for #250. I managed to trigger it locally on my Mac by looping that one test for a few dozen test runs.

This issue is explicitly called out in the BUGS section of the darwin `inet_ntoa` manpage: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/inet_ntoa.3.html

This isn't a problem with glibc because inet_ntoa returns a thread-local string there but it is a problem for musl which also [returns a static string](https://git.musl-libc.org/cgit/musl/tree/src/network/inet_ntoa.c#n6).

Rather than trying to parse exactly what situations allow you to use this API with threads, I've just marked the test unconditionally thread-unsafe.

While I was touching this code, I also moved the win32 skip to a static skipif decorator, which is generally preferred over a runtime check in the test body.