### PR TITLE
Fix PyText_AS_UTF8/PyUnicode_AsUTF8 NULL dereference vulnerabilities

### DIFF
--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -2164,9 +2164,15 @@ static PyObject *cdata_repr(CDataObject *cd)
         extra = " &";
     else
         extra = "";
+
+    const char *s_utf8 = PyText_AsUTF8(s);
+    if (s_utf8 == NULL) {
+        Py_DECREF(s);
+        return NULL;
+    }
     result = PyUnicode_FromFormat("<cdata '%s%s' %s>",
                                cd->c_type->ct_name, extra,
-                               PyUnicode_AsUTF8(s));
+                               s_utf8);
     Py_DECREF(s);
     return result;
 }
@@ -2176,8 +2182,14 @@ static PyObject *_cdata_repr2(CDataObject *cd, char *text, PyObject *x)
     PyObject *res, *s = PyObject_Repr(x);
     if (s == NULL)
         return NULL;
+
+    const char *s_utf8 = PyText_AsUTF8(s);
+    if (s_utf8 == NULL) {
+        Py_DECREF(s);
+        return NULL;
+    }
     res = PyUnicode_FromFormat("<cdata '%s' %s %s>",
-                            cd->c_type->ct_name, text, PyUnicode_AsUTF8(s));
+                            cd->c_type->ct_name, text, s_utf8);
     Py_DECREF(s);
     return res;
 }
@@ -4488,7 +4500,14 @@ static void *b_do_dlopen(PyObject *args, const char **p_printable_filename,
             return NULL;
         }
         *p_temp = PyUnicode_FromFormat("%p", handle);
+        if (*p_temp == NULL)
+            return NULL;
         *p_printable_filename = PyUnicode_AsUTF8(*p_temp);
+        if (*p_printable_filename == NULL) {
+            Py_DECREF(*p_temp);
+            *p_temp = NULL;
+            return NULL;
+        }
         *auto_close = 0;
         return handle;
     }
@@ -5069,8 +5088,12 @@ _add_field(PyObject *interned_fields, PyObject *fname, CTypeDescrObject *ftype,
         return NULL;
 
     if (PyDict_Size(interned_fields) != prev_size + 1) {
+        const char *name_utf8 = PyUnicode_AsUTF8(fname);
+         if (name_utf8 == NULL) {
+             return NULL;
+         }
         PyErr_Format(PyExc_KeyError, "duplicate field name '%s'",
-                     PyUnicode_AsUTF8(fname));
+                     name_utf8);
         return NULL;
     }
     return cf;   /* borrowed reference */
@@ -5217,9 +5240,13 @@ static PyObject *b_complete_struct_or_union_lock_held(CTypeDescrObject *ct,
                 ct->ct_flags_mut |= CT_WITH_VAR_ARRAY;
             }
             else {
+                const char *fname_utf8 = PyText_AS_UTF8(fname);
+                if (fname_utf8 == NULL) {
+                    goto finally;
+                }
                 PyErr_Format(PyExc_TypeError,
                              "field '%s.%s' has ctype '%s' of unknown size",
-                             ct->ct_name, PyUnicode_AsUTF8(fname),
+                             ct->ct_name, fname_utf8,
                              ftype->ct_name);
                 goto finally;
             }
@@ -5287,9 +5314,13 @@ static PyObject *b_complete_struct_or_union_lock_held(CTypeDescrObject *ct,
             if (foffset >= 0) {
                 /* a forced field position: ignore the offset just computed,
                    except to know if we must set CT_CUSTOM_FIELD_POS  */
+                const char *fname_utf8 = PyUnicode_AsUTF8(fname);
+                if (fname_utf8 == NULL) {
+                    goto finally;
+                }
                 if (detect_custom_layout(ct, sflags, byteoffset, foffset,
                                          "wrong offset for field '",
-                                         PyUnicode_AsUTF8(fname), "'") < 0)
+                                         fname_utf8, "'") < 0)
                     goto finally;
                 byteoffset = foffset;
             }
@@ -5333,27 +5364,40 @@ static PyObject *b_complete_struct_or_union_lock_held(CTypeDescrObject *ct,
             int bits_already_occupied, bitshift;
 
             if (foffset >= 0) {
+                const char *fname_utf8 = PyUnicode_AsUTF8(fname);
+                if (fname_utf8 == NULL) {
+                    goto finally;
+                }
+
                 PyErr_Format(PyExc_TypeError,
                              "field '%s.%s' is a bitfield, "
                              "but a fixed offset is specified",
-                             ct->ct_name, PyUnicode_AsUTF8(fname));
+                             ct->ct_name, fname_utf8);
                 goto finally;
             }
 
             if (!(ftype->ct_flags & (CT_PRIMITIVE_SIGNED |
                                      CT_PRIMITIVE_UNSIGNED |
                                      CT_PRIMITIVE_CHAR))) {
+                const char *fname_utf8 = PyUnicode_AsUTF8(fname);
+                if (fname_utf8 == NULL) {
+                    goto finally;
+                }
                 PyErr_Format(PyExc_TypeError,
                         "field '%s.%s' declared as '%s' cannot be a bit field",
-                             ct->ct_name, PyUnicode_AsUTF8(fname),
+                             ct->ct_name, fname_utf8,
                              ftype->ct_name);
                 goto finally;
             }
             if (fbitsize > 8 * ftype->ct_size) {
+                const char *fname_utf8 = PyUnicode_AsUTF8(fname);
+                if (fname_utf8 == NULL) {
+                    goto finally;
+                }
                 PyErr_Format(PyExc_TypeError,
                              "bit field '%s.%s' is declared '%s:%d', which "
                              "exceeds the width of the type",
-                             ct->ct_name, PyUnicode_AsUTF8(fname),
+                             ct->ct_name, fname_utf8,
                              ftype->ct_name, fbitsize);
                 goto finally;
             }
@@ -5366,9 +5410,13 @@ static PyObject *b_complete_struct_or_union_lock_held(CTypeDescrObject *ct,
 
             if (fbitsize == 0) {
                 if (PyUnicode_GetLength(fname) > 0) {
+                    const char *fname_utf8 = PyUnicode_AsUTF8(fname);
+                    if (fname_utf8 == NULL) {
+                        goto finally;
+                    }
                     PyErr_Format(PyExc_TypeError,
                                  "field '%s.%s' is declared with :0",
-                                 ct->ct_name, PyUnicode_AsUTF8(fname));
+                                 ct->ct_name, fname_utf8);
                     goto finally;
                 }
                 if (!(sflags & SF_MSVC_BITFIELDS)) {
@@ -5405,10 +5453,14 @@ static PyObject *b_complete_struct_or_union_lock_held(CTypeDescrObject *ct,
                            allowed position */
                         if ((sflags & SF_PACKED) &&
                             (bits_already_occupied & 7)) {
+                            const char *fname_utf8 = PyUnicode_AsUTF8(fname);
+                            if (fname_utf8 == NULL) {
+                                goto finally;
+                            }
                             PyErr_Format(PyExc_NotImplementedError,
                                 "with 'packed', gcc would compile field "
                                 "'%s.%s' to reuse some bits in the previous "
-                                "field", ct->ct_name, PyUnicode_AsUTF8(fname));
+                                "field", ct->ct_name, fname_utf8);
                             goto finally;
                         }
                         field_offset_bytes += falign;

--- a/src/c/cglob.c
+++ b/src/c/cglob.c
@@ -73,8 +73,14 @@ static void *fetch_global_var_addr(GlobSupportObject *gs)
         Py_END_ALLOW_THREADS
     }
     if (data == NULL) {
+        
+        const char *name_utf8 = PyText_AS_UTF8(gs->gs_name);
+               if (name_utf8 == NULL) {
+                 return NULL;
+        }
         PyErr_Format(FFIError, "global variable '%s' is at address NULL",
-                     PyUnicode_AsUTF8(gs->gs_name));
+                    name_utf8);
+
         return NULL;
     }
     return data;

--- a/src/c/ffi_obj.c
+++ b/src/c/ffi_obj.c
@@ -192,6 +192,9 @@ static CTypeDescrObject *_ffi_type(FFIObject *ffi, PyObject *arg,
 
         if (x == NULL) {
             const char *input_text = PyUnicode_AsUTF8(arg);
+            if (input_text == NULL) {
+               return NULL;
+         }
             struct _cffi_parse_info_s info;
             info.ctx = &ffi->types_builder.ctx;
             info.output_size = FFI_COMPLEXITY_OUTPUT;


### PR DESCRIPTION
### Description

Hi maintainers,

During a robustness audit of Python C‑API contracts using a static analysis tool, we identified a systematic pattern of **unchecked `PyText_AS_UTF8` / `PyUnicode_AsUTF8` return values** across multiple files in the `_cffi_backend` C extension.

These functions can return `NULL` when:
1. The input string contains invalid surrogate characters, triggering `UnicodeEncodeError`
2. Memory allocation fails (OOM), triggering `MemoryError`

When the return value is `NULL` and passed directly to `PyErr_Format` or `PyUnicode_FromFormat` with a `%s` format specifier, it causes `strlen(NULL)` → **Segmentation Fault**, crashing the interpreter.

This PR adds NULL checks before passing UTF-8 strings to any string-consuming API, ensuring errors are properly propagated rather than crashing.


### 1. Unchecked `PyText_AS_UTF8` / `PyUnicode_AsUTF8` return → NULL dereference

**Location:** Multiple functions across `src/c/_cffi_backend.c`, `src/c/cglob.c`, `src/c/ffi_obj.c`

**Issue:**  
`PyText_AS_UTF8` (macro for `PyUnicode_AsUTF8`) is called and its return value is passed directly to `PyErr_Format`, `PyUnicode_FromFormat`, `parse_c_type`, or `detect_custom_layout` without checking for `NULL`. If the string contains invalid surrogate characters (e.g., `\uD800`) or memory allocation fails, the function returns `NULL` and sets an exception. Passing `NULL` to a `%s` format specifier causes `strlen(NULL)` → **Segmentation Fault**, killing the interpreter.

**Fix:**  
Check the return value of `PyText_AS_UTF8` / `PyUnicode_AsUTF8` before using it. If `NULL`, propagate the already-set exception by returning `NULL` or `-1`.

**Affected functions:**

| File | Function |
|------|----------|
| `src/c/cglob.c` | `fetch_global_var_addr` |
| `src/c/ffi_obj.c` | `_ffi_type` |
| `src/c/_cffi_backend.c` | `cdata_repr`, `_cdata_repr2`, `_add_field`, `b_complete_struct_or_union_lock_held` (6 locations), `b_do_dlopen` |

**Example fix (`cglob.c`):**

```diff
- PyErr_Format(FFIError, "global variable '%s' is at address NULL",
-              PyUnicode_AsUTF8(gs->gs_name));
+ const char *name_utf8 = PyUnicode_AsUTF8(gs->gs_name);
+ if (name_utf8 == NULL) {
+     return NULL;
+ }
+ PyErr_Format(FFIError, "global variable '%s' is at address NULL",
+              name_utf8);
```

Same fix applied to all PyErr_Format calls with unchecked %s parameters:

```c
/* Before: */
PyErr_Format(PyExc_TypeError, "field '%s.%s' ...", ct->ct_name, PyUnicode_AsUTF8(fname));

/* After: */
const char *fname_utf8 = PyUnicode_AsUTF8(fname);
if (fname_utf8 == NULL) {
    goto finally;  /* or return NULL */
}
PyErr_Format(PyExc_TypeError, "field '%s.%s' ...", ct->ct_name, fname_utf8);
```
### Impact & Rationale

- **Availability:** A crash in `cffi` can take down the entire Python process with no recoverable error. `cffi` is a foundational library used by thousands of projects including `cryptography`, `bcrypt`, `gevent`, and `PyPy`.

- **Reachability:** The vulnerability is reachable when:
  - User-provided strings containing invalid surrogate characters are passed to `ffi.cast()`, `ffi.typeof()`, or struct field definitions
  - Memory pressure causes `PyUnicode_AsUTF8` to fail with `MemoryError`

- **Debuggability:** In the `%s` format specifier case, the original exception is lost and replaced by a crash, making debugging extremely difficult.

**Note:** All changes are minimal and backward‑compatible – they only affect error paths, leaving the happy path unchanged.

---

Thank you for maintaining `cffi`!