### PR TITLE
riscv64: add manylinux, musllinux to matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,16 @@ jobs:
           - { spec: cp315-manylinux_s390x, arch: s390x, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs }} }
           - { spec: cp315t-manylinux_s390x, arch: s390x, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs }} }
 
+          # riscv64gc manylinux
+          - { spec: cp310-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs }} }
+          - { spec: cp311-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs || env.skip_ci_redundant_jobs }} }
+          - { spec: cp312-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs || env.skip_ci_redundant_jobs }} }
+          - { spec: cp313-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs || env.skip_ci_redundant_jobs }} }
+          - { spec: cp314-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs || env.skip_ci_redundant_jobs }} }
+          - { spec: cp314t-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs || env.skip_ci_redundant_jobs }} }
+          - { spec: cp315-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs }} }
+          - { spec: cp315t-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs }} }
+
   linux:
     needs: [python_sdist, make_linux_matrix]
     runs-on: ${{ (matrix.arch == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
@@ -184,9 +194,11 @@ jobs:
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_img || 'manylinux2014' }}
         CIBW_MANYLINUX_PPC64LE_IMAGE: ${{ matrix.manylinux_img || 'manylinux2014' }}
         CIBW_MANYLINUX_S390X_IMAGE: ${{ matrix.manylinux_img || 'manylinux2014' }}
+        CIBW_MANYLINUX_RISCV64_IMAGE: ${{ matrix.manylinux_img || 'manylinux_2_39' }}
         CIBW_MUSLLINUX_X86_64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}
         CIBW_MUSLLINUX_I686_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}
         CIBW_MUSLLINUX_AARCH64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}
+        CIBW_MUSLLINUX_RISCV64_IMAGE: ${{ matrix.musllinux_img || 'musllinux_1_2' }}
         CIBW_TEST_REQUIRES: pytest setuptools meson-python ninja # 3.12+ no longer includes distutils, just always ensure setuptools is present
         CIBW_TEST_COMMAND: PYTHONUNBUFFERED=1 python -m pytest ${{ matrix.test_args || '{project}' }}  # default to test all
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,16 @@ jobs:
           - { spec: cp315-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs }} }
           - { spec: cp315t-manylinux_riscv64, arch: riscv64, test_args: '{package}/src/c', omit: ${{ env.skip_slow_jobs }} }
 
+          # riscv64 musllinux
+          - { spec: cp310-musllinux_riscv64, arch: riscv64, omit: ${{ env.skip_ci_redundant_jobs }} }
+          - { spec: cp311-musllinux_riscv64, arch: riscv64, omit: ${{ env.skip_ci_redundant_jobs }} }
+          - { spec: cp312-musllinux_riscv64, arch: riscv64, omit: ${{ env.skip_ci_redundant_jobs }} }
+          - { spec: cp313-musllinux_riscv64, arch: riscv64, omit: ${{ env.skip_ci_redundant_jobs }} }
+          - { spec: cp314-musllinux_riscv64, arch: riscv64, omit: ${{ env.skip_ci_redundant_jobs }} }
+          - { spec: cp314t-musllinux_riscv64, arch: riscv64, omit: ${{ env.skip_ci_redundant_jobs }} }
+          - { spec: cp315-musllinux_riscv64, arch: riscv64 }
+          - { spec: cp315t-musllinux_riscv64, arch: riscv64 }
+
   linux:
     needs: [python_sdist, make_linux_matrix]
     runs-on: ${{ (matrix.arch == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}


### PR DESCRIPTION
This adds riscv64 builds for both manylinux and musllinux to the CI matrix. Some Python packages run into issues building for musllinux (that wasn't the case here), so I separated the additions into distinct commits to make a rebase/revert easier if needed.

[Here](https://github.com/threexc/cffi/actions/runs/34298857623) is a dry run I did on my fork, with these changes and extra `revertme` commits to only run riscv64 jobs and to restrict the triggers.